### PR TITLE
fix: Check the driver for the correct database connection.

### DIFF
--- a/database/migrations/2019_03_35_000001_create_logger_tables.php
+++ b/database/migrations/2019_03_35_000001_create_logger_tables.php
@@ -2,6 +2,7 @@
 
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 
 class CreateLoggerTables extends Migration
@@ -13,7 +14,7 @@ class CreateLoggerTables extends Migration
      */
     public function up()
     {
-        if (config('database.default') !== 'mysql') {
+        if (DB::connection()->getDriverName() !== 'mysql') {
             throw new \InvalidArgumentException("MySQL is the only supported driver for this package.");
         }
 

--- a/database/migrations/2019_03_35_000002_update_logger_tables.php
+++ b/database/migrations/2019_03_35_000002_update_logger_tables.php
@@ -2,6 +2,7 @@
 
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 use Sourcetoad\Logger\Models\AuditChange;
 use Sourcetoad\Logger\Models\AuditKey;
@@ -10,7 +11,7 @@ class UpdateLoggerTables extends Migration
 {
     public function up()
     {
-        if (config('database.default') !== 'mysql') {
+        if (DB::connection()->getDriverName() !== 'mysql') {
             throw new \InvalidArgumentException("MySQL is the only supported driver for this package.");
         }
 

--- a/database/migrations/2019_03_35_000003_drop_unused_logger_columns.php
+++ b/database/migrations/2019_03_35_000003_drop_unused_logger_columns.php
@@ -2,13 +2,14 @@
 
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 
 class DropUnusedLoggerColumns extends Migration
 {
     public function up()
     {
-        if (config('database.default') !== 'mysql') {
+        if (DB::connection()->getDriverName() !== 'mysql') {
             throw new \InvalidArgumentException("MySQL is the only supported driver for this package.");
         }
 


### PR DESCRIPTION
 Many commands (such as `artisan migrate`) accept a database connection
argument. In these cases the value returned by `config(database.default)`
is the connection name and is not `mysql`. This checks the driver for
the current database connection instead.