### PR TITLE
build: support for laravel 9, drop php 7

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [7.3, 7.4, 8.0]
+        php: [8.0, 8.1]
         stability: [prefer-lowest, prefer-stable]
     name: PHP ${{ matrix.php }} - ${{ matrix.stability }}
     steps:
@@ -56,7 +56,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.0'
+          php-version: '8.1'
           coverage: none
 
       - name: Install dependencies

--- a/composer.json
+++ b/composer.json
@@ -14,11 +14,11 @@
     "require": {
         "ext-json": "*",
         "php": ">=7.1.3",
-        "illuminate/auth": "^6.0|^7.0|^8.0",
-        "illuminate/config": "^6.0|^7.0|^8.0",
-        "illuminate/database": "^6.0|^7.0|^8.0",
-        "illuminate/support": "^6.0|^7.0|^8.0",
-        "illuminate/translation": "^6.0|^7.0|^8.0"
+        "illuminate/auth": "^6.0|^7.0|^8.0|^9.0",
+        "illuminate/config": "^6.0|^7.0|^8.0|^9.0",
+        "illuminate/database": "^6.0|^7.0|^8.0|^9.0",
+        "illuminate/support": "^6.0|^7.0|^8.0|^9.0",
+        "illuminate/translation": "^6.0|^7.0|^8.0|^9.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -13,12 +13,12 @@
     "prefer-stable": true,
     "require": {
         "ext-json": "*",
-        "php": ">=7.1.3",
-        "illuminate/auth": "^6.0|^7.0|^8.0|^9.0",
-        "illuminate/config": "^6.0|^7.0|^8.0|^9.0",
-        "illuminate/database": "^6.0|^7.0|^8.0|^9.0",
-        "illuminate/support": "^6.0|^7.0|^8.0|^9.0",
-        "illuminate/translation": "^6.0|^7.0|^8.0|^9.0"
+        "php": ">=8.0.2",
+        "illuminate/auth": "^9.0",
+        "illuminate/config": "^9.0",
+        "illuminate/database": "^9.0",
+        "illuminate/support": "^9.0",
+        "illuminate/translation": "^9.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
This will turn in the next major tag, dropping old Laravel and PHP versions.