### PR TITLE
build: migrate to non-deprecated phpunit config

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -14,9 +14,9 @@
             <directory>tests</directory>
         </testsuite>
     </testsuites>
-    <filter>
-        <whitelist>
+    <coverage>
+        <include>
             <directory suffix=".php">src/</directory>
-        </whitelist>
-    </filter>
+        </include>
+    </coverage>
 </phpunit>


### PR DESCRIPTION
```
Runtime:       PHP 8.1.14
Configuration: /home/runner/work/Logger/Logger/phpunit.xml
Warning:       Your XML configuration validates against a deprecated schema.
Suggestion:    Migrate your XML configuration using "--migrate-configuration"!
```

Resolves this warning.