### PR TITLE
[Master] v5.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# v5.0.1 (July 18, 2024)
+ * Remove throws on down methods for migrations.
+
 # v5.0.0 (July 16, 2024)
  * Add Laravel 11 support
  * Drop PHP <= 8.1 support


### PR DESCRIPTION
# v5.0.1 (July 18, 2024)
 * Remove throws on down methods for migrations.
