### PR TITLE
Fix down migration in create_logger_tables

### DIFF
--- a/database/migrations/2019_03_35_000001_create_logger_tables.php
+++ b/database/migrations/2019_03_35_000001_create_logger_tables.php
@@ -132,11 +132,11 @@ class CreateLoggerTables extends Migration
     public function down(): void
     {
         Schema::disableForeignKeyConstraints();
-        Schema::drop('audit_changes');
-        Schema::drop('audit_routes');
-        Schema::drop('audit_keys');
-        Schema::drop('audit_models');
-        Schema::drop('audit_activities');
+        Schema::dropIfExists('audit_models');
+        Schema::dropIfExists('audit_changes');
+        Schema::dropIfExists('audit_activities');
+        Schema::dropIfExists('audit_routes');
+        Schema::dropIfExists('audit_keys');
         Schema::enableForeignKeyConstraints();
     }
 }


### PR DESCRIPTION
An issue occurred in one of our other projects, where when a Dusk test attempted to rollback the migration it hit the below error. 

This pr fixes this by rearranging the order of the down migration drops.

![Screenshot 2024-10-31 at 12 35 35 PM](https://github.com/user-attachments/assets/f25b856b-c355-4286-b395-d8fe05331e1e)
