### PR TITLE
[Release] v6.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,11 @@
+# v6.0.0 (November 19, 2024)
+ * Drop User model associations on tracked entities in favor of polymorphic "owner" associations.
+
 # v5.1.1 (October 31, 2024)
-* Fix down migration for create_logger_tables.
+ * Fix down migration for create_logger_tables.
 
 # v5.1.0 (October 31, 2024)
-* Add support for Postgres.
+ * Add support for Postgres.
 
 # v5.0.1 (July 18, 2024)
  * Remove throws on down methods for migrations.


### PR DESCRIPTION
### Changelog
* Drop User model associations on tracked entities in favor of polymorphic "owner" associations.

> [!CAUTION]
> This is a major version bump.
> 
> This version drops the `user_id` column from both the `audit_changes` and `audit_models` tables. That column as been replaced by the `owner_type` and `owner_id` columns in both tables.
> 
> Any projects that use this package will need to re-run migrations.