### PR TITLE
Fix Owner Morph Class Resolution and Add Check for `0` in Morph Map Keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,11 +59,14 @@ Due to the large amount of records anticipated to be created, you must create an
 return [
 
     'morphs' => [
-        0 => App\Models\User::class
+        1 => App\Models\User::class
     ],
 
 ];
 ```
+
+> [!CAUTION]
+> `0` is not a valid key for the morph map, as it will get resolved to `false` in Laravel's morphing logic.
 
 This points our `App\Models\User::class` to an enum (integer). This means our database is created with small integers vs large fully qualified namespaces.
 

--- a/src/Commands/AuditModelResolver.php
+++ b/src/Commands/AuditModelResolver.php
@@ -3,6 +3,7 @@
 namespace Sourcetoad\Logger\Commands;
 
 use Illuminate\Console\Command;
+use Sourcetoad\Logger\Logger;
 use Sourcetoad\Logger\Helpers\AuditResolver;
 use Sourcetoad\Logger\Models\AuditChange;
 use Sourcetoad\Logger\Models\AuditModel;
@@ -21,7 +22,7 @@ class AuditModelResolver extends Command
 
                 $item->processed = true;
                 $item->owner_id = $owner?->getKey();
-                $item->owner_type = $owner?->getMorphClass();
+                $item->owner_type = !is_null($owner) ? Logger::getNumericMorphMap($owner) : null;
                 $item->saveOrFail();
             }
         });
@@ -33,7 +34,7 @@ class AuditModelResolver extends Command
 
                 $item->processed = true;
                 $item->owner_id = $owner?->getKey();
-                $item->owner_type = $owner?->getMorphClass();
+                $item->owner_type = !is_null($owner) ? Logger::getNumericMorphMap($owner) : null;
                 $item->saveOrFail();
             }
         });

--- a/src/Logger.php
+++ b/src/Logger.php
@@ -124,7 +124,7 @@ class Logger
 
                 $data[] = [
                     'activity_id' => $activity->id,
-                    'entity_type' => $this->getNumericMorphMap($model),
+                    'entity_type' => static::getNumericMorphMap($model),
                     'entity_id'   => $model->getKey(),
                     'key_id'      => $keys->id,
                     'processed'   => false,
@@ -156,7 +156,7 @@ class Logger
 
             $data[] = [
                 'activity_id' => $activity->id,
-                'entity_type' => $this->getNumericMorphMap($model),
+                'entity_type' => static::getNumericMorphMap($model),
                 'entity_id'   => $model->getKey(),
                 'processed'   => false,
             ];
@@ -171,7 +171,7 @@ class Logger
     // Private functions
     //--------------------------------------------------------------------------------------------------------------
 
-    private function getNumericMorphMap(Model $model): int
+    public static function getNumericMorphMap(Model $model): int
     {
         $fcqn = get_class($model);
         $morphMap = LoggerServiceProvider::$morphs;

--- a/src/Logger.php
+++ b/src/Logger.php
@@ -5,6 +5,7 @@ namespace Sourcetoad\Logger;
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\Request;
+use InvalidArgumentException;
 use Sourcetoad\Logger\Enums\ActivityType;
 use Sourcetoad\Logger\Enums\HttpVerb;
 use Sourcetoad\Logger\Models\AuditActivity;
@@ -181,11 +182,19 @@ class Logger
             $morphableTypeId = array_search($fcqn, $morphMap, true);
         }
 
-        if (is_numeric($morphableTypeId)) {
-            return $morphableTypeId;
+        if (!is_numeric($morphableTypeId)) {
+            throw new InvalidArgumentException(
+                sprintf('%s has no numeric model map. Check `morphs` in Logger.', get_class($model)),
+            );
         }
 
-        throw new \InvalidArgumentException(get_class($model) . " has no numeric model map. Check `morphs` in Logger.");
+        if ($morphableTypeId === 0) {
+            throw new InvalidArgumentException(
+                sprintf('0 is not a valid morph map key for %s. Check `morphs` in Logger.', get_class($model)),
+            );
+        }
+
+        return $morphableTypeId;
     }
 
     private function getHttpVerb(string $verb): int


### PR DESCRIPTION
Because of the changes made in this [commit](https://github.com/sourcetoad/Logger/pull/53/commits/21fd70b436e5c894f1ae93cab0224acb62256796), the output of `getMorphClass` on the polymorphic owner is incompatible with the `audit_changes.owner_type` and `audit_models.owner_type` columns.

This PR also adds error checking against morph maps with a `0`-key, as they ultimately get resolved to `false` deep in Laravel's relationship logic, which prevents models with that key from being morphed properly.