### PR TITLE
chore: drop Laravel 11 support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,7 @@ jobs:
       fail-fast: true
       matrix:
         php: [8.2, 8.3, 8.4, 8.5]
-        laravel: [11.0, 12.0, 13.0]
+        laravel: [12.0, 13.0]
         exclude:
           - php: 8.2
             laravel: 13.0

--- a/README.md
+++ b/README.md
@@ -23,8 +23,9 @@ This means that the method for storage must be efficient, unlike other packages 
 
 ### Laravel
 
-You are reading the documentation for Laravel 11.x, 12.x, and 13.x.
+You are reading the documentation for Laravel 12.x, and 13.x.
 
+* If you're using Laravel 11 please see the docs for [6.x](https://github.com/sourcetoad/Logger/tree/v6.2.0).
 * If you're using Laravel 9 or 10 please see the docs for [4.x](https://github.com/sourcetoad/Logger/releases/tag/v4.2.0).
 * If you're using Laravel 6, 7 or 8 please see the docs for [3.x](https://github.com/sourcetoad/Logger/releases/tag/v3.0.1).
 * If you're using Laravel 5 or below please see docs for [1.x](https://github.com/sourcetoad/Logger/releases/tag/v1.3.0)

--- a/composer.json
+++ b/composer.json
@@ -17,11 +17,11 @@
     "require": {
         "ext-json": "*",
         "php": "^8.2||^8.3||^8.4||^8.5",
-        "illuminate/auth": "^11.0|^12.0|^13.0",
-        "illuminate/config": "^11.0|^12.0|^13.0",
-        "illuminate/database": "^11.0|^12.0|^13.0",
-        "illuminate/support": "^11.0|^12.0|^13.0",
-        "illuminate/translation": "^11.0|^12.0|^13.0"
+        "illuminate/auth": "^12.0|^13.0",
+        "illuminate/config": "^12.0|^13.0",
+        "illuminate/database": "^12.0|^13.0",
+        "illuminate/support": "^12.0|^13.0",
+        "illuminate/translation": "^12.0|^13.0"
     },
     "require-dev": {
         "laravel/pint": "1.21",


### PR DESCRIPTION
Laravel 11 is EOL now - https://endoflife.date/laravel